### PR TITLE
Updated autotools to build testset using the included 'tinyxml' sources

### DIFF
--- a/APL/PhysicalLayerAsyncBaseTCP.cpp
+++ b/APL/PhysicalLayerAsyncBaseTCP.cpp
@@ -47,7 +47,7 @@ PhysicalLayerAsyncBaseTCP::PhysicalLayerAsyncBaseTCP(Logger* apLogger, boost::as
 
 void PhysicalLayerAsyncBaseTCP::DoClose()
 {
-	error_code ec;
+	boost::system::error_code ec;
 	mSocket.close(ec);
 	if(ec) LOG_BLOCK(LEV_WARNING, ec.message());
 }
@@ -63,13 +63,20 @@ void PhysicalLayerAsyncBaseTCP::DoOpenSuccess()
 void PhysicalLayerAsyncBaseTCP::DoAsyncRead(boost::uint8_t* apBuffer, size_t aMaxBytes)
 {
 	mSocket.async_read_some(buffer(apBuffer, aMaxBytes),
-	                        boost::bind(&PhysicalLayerAsyncBaseTCP::OnReadCallback, this, placeholders::error, apBuffer, placeholders::bytes_transferred));
+	                        boost::bind(&PhysicalLayerAsyncBaseTCP::OnReadCallback,
+							            this,
+							            boost::asio::placeholders::error,
+							            apBuffer,
+							            boost::asio::placeholders::bytes_transferred));
 }
 
 void PhysicalLayerAsyncBaseTCP::DoAsyncWrite(const boost::uint8_t* apBuffer, size_t aNumBytes)
 {
 	async_write(mSocket, buffer(apBuffer, aNumBytes),
-	            boost::bind(&PhysicalLayerAsyncBaseTCP::OnWriteCallback, this, placeholders::error, aNumBytes));
+	            boost::bind(&PhysicalLayerAsyncBaseTCP::OnWriteCallback,
+				            this,
+				            boost::asio::placeholders::error,
+				            aNumBytes));
 }
 
 void PhysicalLayerAsyncBaseTCP::DoOpenFailure()
@@ -80,3 +87,4 @@ void PhysicalLayerAsyncBaseTCP::DoOpenFailure()
 
 }
 
+/* vim: set ts=4 sw=4: */

--- a/APL/PhysicalLayerAsyncSerial.cpp
+++ b/APL/PhysicalLayerAsyncSerial.cpp
@@ -65,7 +65,7 @@ void PhysicalLayerAsyncSerial::DoOpen()
 
 void PhysicalLayerAsyncSerial::DoClose()
 {
-	error_code ec;
+	boost::system::error_code ec;
 	mPort.close(ec);
 	if(ec) LOG_BLOCK(LEV_WARNING, ec.message());
 }
@@ -78,14 +78,22 @@ void PhysicalLayerAsyncSerial::DoOpenSuccess()
 void PhysicalLayerAsyncSerial::DoAsyncRead(boost::uint8_t* apBuffer, size_t aMaxBytes)
 {
 	mPort.async_read_some(buffer(apBuffer, aMaxBytes),
-	                      boost::bind(&PhysicalLayerAsyncSerial::OnReadCallback, this, placeholders::error, apBuffer, placeholders::bytes_transferred));
+	                      boost::bind(&PhysicalLayerAsyncSerial::OnReadCallback,
+						              this,
+						              boost::asio::placeholders::error,
+						              apBuffer,
+						              boost::asio::placeholders::bytes_transferred));
 }
 
 void PhysicalLayerAsyncSerial::DoAsyncWrite(const boost::uint8_t* apBuffer, size_t aNumBytes)
 {
 	async_write(mPort, buffer(apBuffer, aNumBytes),
-	            boost::bind(&PhysicalLayerAsyncSerial::OnWriteCallback, this, placeholders::error, aNumBytes));
+	            boost::bind(&PhysicalLayerAsyncSerial::OnWriteCallback,
+				            this,
+				            boost::asio::placeholders::error,
+				            aNumBytes));
 }
 
 }
 
+/* vim: set ts=4 sw=4: */

--- a/APL/PhysicalLayerAsyncTCPClient.cpp
+++ b/APL/PhysicalLayerAsyncTCPClient.cpp
@@ -52,7 +52,10 @@ PhysicalLayerAsyncTCPClient::PhysicalLayerAsyncTCPClient(
 /* Implement the actions */
 void PhysicalLayerAsyncTCPClient::DoOpen()
 {
-	mSocket.async_connect(mRemoteEndpoint, boost::bind(&PhysicalLayerAsyncTCPClient::OnOpenCallback, this, placeholders::error));
+	mSocket.async_connect(mRemoteEndpoint,
+	                      boost::bind(&PhysicalLayerAsyncTCPClient::OnOpenCallback,
+			                  this,
+			                  boost::asio::placeholders::error));
 }
 
 void PhysicalLayerAsyncTCPClient::DoOpenSuccess()
@@ -62,3 +65,4 @@ void PhysicalLayerAsyncTCPClient::DoOpenSuccess()
 
 }
 
+/* vim: set ts=4 sw=4: */

--- a/APL/PhysicalLayerAsyncTCPServer.cpp
+++ b/APL/PhysicalLayerAsyncTCPServer.cpp
@@ -51,7 +51,7 @@ PhysicalLayerAsyncTCPServer::PhysicalLayerAsyncTCPServer(Logger* apLogger, boost
 void PhysicalLayerAsyncTCPServer::DoOpen()
 {
 	if(!mAcceptor.is_open()) {
-		error_code ec;
+		boost::system::error_code ec;
 		mAcceptor.open(mLocalEndpoint.protocol(), ec);
 		if(ec) throw Exception(LOCATION, ec.message());
 
@@ -63,7 +63,11 @@ void PhysicalLayerAsyncTCPServer::DoOpen()
 		if(ec) throw Exception(LOCATION, ec.message());
 	}
 
-	mAcceptor.async_accept(mSocket, mRemoteEndpoint, boost::bind(&PhysicalLayerAsyncTCPServer::OnOpenCallback, this, placeholders::error));
+	mAcceptor.async_accept(mSocket,
+	                       mRemoteEndpoint,
+						   boost::bind(&PhysicalLayerAsyncTCPServer::OnOpenCallback,
+						               this,
+						               boost::asio::placeholders::error));
 }
 
 void PhysicalLayerAsyncTCPServer::DoOpenCallback()
@@ -91,3 +95,4 @@ void PhysicalLayerAsyncTCPServer::DoOpenSuccess()
 
 }
 
+/* vim: set ts=4 sw=4: */

--- a/DNP3/EnhancedVto.cpp
+++ b/DNP3/EnhancedVto.cpp
@@ -30,7 +30,7 @@ namespace apl
 namespace dnp
 {
 
-const char EnhancedVto::MAGIC_BYTES[MAGIC_BYTES_SIZE] = {0xAB, 0xBC, 0xCD};
+const char EnhancedVto::MAGIC_BYTES[MAGIC_BYTES_SIZE] = {'\xAB', '\xBC', '\xCD'};
 
 VtoData EnhancedVto::CreateVtoData(bool aLocalVtoConnectionOpened, boost::uint8_t aChannelId)
 {
@@ -58,5 +58,4 @@ void EnhancedVto::ReadVtoData(const VtoData& arData, bool& arLocalVtoConnectionO
 }
 
 /* vim: set ts=4 sw=4: */
-
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -347,15 +347,10 @@ nobase_pkginclude_HEADERS= \
 	DNP3/VtoTransmitTask.h \
 	DNP3/VtoWriter.h
 
-if ENABLE_TESTSET
-TESTSET_APP = testset
-else
-TESTSET_APP =
-endif
-
-bin_PROGRAMS  = ${TESTSET_APP} dnp3test
+bin_PROGRAMS = testset
 
 testset_LDADD = libopendnp3_apl.la libopendnp3_dnp3.la
+testset_CFLAGS = -Itinyxml
 testset_SOURCES = \
 	APLXML/PhysicalLayerManagerXML.cpp \
 	APLXML/PhysicalLayerXMLFactory.cpp \
@@ -381,7 +376,12 @@ testset_SOURCES = \
 	XMLBindings/APLXML_Base.cpp \
 	XMLBindings/APLXML_DNP.cpp \
 	XMLBindings/APLXML_MTS.cpp \
-	XMLBindings/APLXML_STS.cpp
+	XMLBindings/APLXML_STS.cpp \
+	tinyxml/tinyxml.cpp \
+	tinyxml/tinyxmlerror.cpp \
+	tinyxml/tinyxmlparser.cpp
+
+noinst_PROGRAMS = dnp3test
 
 dnp3test_LDADD = libopendnp3_apl.la libopendnp3_dnp3.la
 dnp3test_SOURCES = \

--- a/README
+++ b/README
@@ -79,7 +79,6 @@ Requirements:
     * Boost Unit Test Framework     (required)
   - lcov                            (required if running 'make lcov')
   - libtool                         (required)
-  - tinyxml                         (required if 'testset' is desired)
 
 To start, first reinitialize autotools to be compatible with the version
 running on your system:
@@ -90,9 +89,7 @@ Next, run the 'configure' script:
 
   ./configure
 
-A full list of options can be found using './configure --help'.  If
-tinyxml is not found, a warning message is printed and the 'testset'
-application will not be built.
+A full list of options can be found using './configure --help'.
 
 You can now build the OpenDNP3 libraries and programs:
 

--- a/configure.ac
+++ b/configure.ac
@@ -72,19 +72,6 @@ AC_CHECK_HEADERS([unistd.h]	,,AC_MSG_ERROR(missing header))
 AC_CHECK_LIB([c],	[atexit]		,,AC_MSG_ERROR(missing library))
 AC_CHECK_LIB([pthread],	[pthread_join]		,,AC_MSG_ERROR(missing library))
 
-AC_CHECK_HEADERS([tinyxml.h],			ac_tinyxml_h_found=yes,		ac_tinyxml_h_found=no)
-AC_CHECK_LIB([tinyxml],	[_ZTI9TiXmlNode],,					ac_tinyxml_lib_found=no)
-
-AC_ARG_ENABLE(testset,
-  AS_HELP_STRING([--enable-testset], [Enable building the testset application]),
-    [ac_testset_enabled=$enableval], [ac_testset_enabled=no])
-if test "$ac_testset_enabled" = yes; then
-  if test "$ac_tinyxml_h_found" = no -o "$ac_tinyxml_lib_found" = no; then
-    AC_MSG_ERROR("missing one or more components of the tinyxml library -- unable to build the testset application!")
-  fi
-fi
-AM_CONDITIONAL(ENABLE_TESTSET, [test "$ac_testset_enabled" = yes])
-
 AC_PROG_AWK
 AC_PROG_CXX
 AC_PROG_GREP
@@ -133,7 +120,6 @@ LDFLAGS:                    ${LDFLAGS}
 LIBS:                       ${LIBS}
 
 lcov support:               ${ac_lcov_enabled}
-testset application:        ${ac_testset_enabled}
 shared libraries:           ${enable_shared}
 static libraries:           ${enable_static}
 -----------------------------------------------------


### PR DESCRIPTION
I updated the GNU autotools build system to always build the testset application by using the 'tinyxml' sources that are included with the rest of the OpenDNP3 sources.  Trying to build testset with an external library/shared object of tinyxml was proving to be a headache, and the size savings wasn't worth it.
