### PR TITLE
Added missing header files to the list in Makefile.am

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,0 +1,1 @@
+See CHANGELOG.markdown.

--- a/DNP3/DNPConstants.h
+++ b/DNP3/DNPConstants.h
@@ -21,8 +21,6 @@
 
 #include <string>
 
-//controls the maximum DNP fragment size
-
 #define MACRO_DNP_RADIX(obj,var) (obj<<4) | var
 
 namespace apl
@@ -32,7 +30,7 @@ namespace dnp
 
 const size_t DEFAULT_FRAG_SIZE = 2048;
 
-/**
+/*
  * The default queue size for a VtoWriter object.  At ~256 bytes of
  * data per queued object, the current size of 1024 allows ~256 KB of
  * data to be buffered.
@@ -41,106 +39,96 @@ const size_t DEFAULT_VTO_WRITER_QUEUE_SIZE = 1024;
 
 enum DNPErrorCodes {
 
-    /// Master slave independent vto error codes
+	/// Master slave independent vto error codes
+	VTOERR_VTO_FOR_UNEXPECTED_CHANNEL,
+	VTOERR_ENHANCED_VTO_FOR_UNREGISTERED_CHANNEL,
+	VTOERR_BAD_VTO_FOR_UNREGISTERED_CHANNEL,
+	VTOERR_BADLY_FORMATTED_ENHANCED_VTO,
 
-    VTOERR_VTO_FOR_UNEXPECTED_CHANNEL,
-    VTOERR_ENHANCED_VTO_FOR_UNREGISTERED_CHANNEL,
-    VTOERR_BAD_VTO_FOR_UNREGISTERED_CHANNEL,
-    VTOERR_BADLY_FORMATTED_ENHANCED_VTO,
+	// Slave error codes
+	SERR_FUNC_NOT_SUPPORTED,
+	SERR_CTRL_NOT_CONVERTIBLE,
+	SERR_MULTIPLE_HDR_INVALID,
+	SERR_MULTIPLE_OBJ_INVALID,
+	SERR_OBJ_FUNC_MISMATCH,
+	SERR_INVALID_IIN_WRITE,
 
-    // Slave error codes
+	// Master error codes
+	MERR_FUNC_NOT_SUPPORTED,
+	MERR_UNEXPECTED_MULTI_FRAG_RSP,
+	MERR_UNSUPPORTED_OBJECT_TYPE,
 
-    SERR_FUNC_NOT_SUPPORTED,
-    SERR_CTRL_NOT_CONVERTIBLE,
-    SERR_MULTIPLE_HDR_INVALID,
-    SERR_MULTIPLE_OBJ_INVALID,
-    SERR_OBJ_FUNC_MISMATCH,
-    SERR_INVALID_IIN_WRITE,
+	// APPLICATION Layer Context
+	ALERR_TIMEOUT,
+	ALERR_BAD_UNSOL_BIT,
+	ALERR_UNEXPECTED_CONFIRM,
+	ALERR_UNEXPECTED_RESPONSE,
+	ALERR_MULTI_FRAGEMENT_REQUEST,
+	ALERR_NOT_FIR_PACKET,
+	ALERR_BAD_FIR_FIN,
+	ALERR_BAD_SEQUENCE,
+	ALERR_BAD_CONFIRM_MESSAGE,
+	ALERR_FRAGMENT_TOO_LARGE,
+	ALERR_UNSOL_FLOOD,
+	ALERR_SOL_FLOOD,
+	ALERR_INVALID_PACKET,
+	ALERR_BAD_STATE,
 
-    // Master error codes
-    MERR_FUNC_NOT_SUPPORTED,
-    MERR_UNEXPECTED_MULTI_FRAG_RSP,
-    MERR_UNSUPPORTED_OBJECT_TYPE,
+	// Application Layer Parsing
+	ALERR_INSUFFICIENT_DATA_FOR_FRAG,			// fragment is less than 2 bytes
+	ALERR_INSUFFICIENT_DATA_FOR_RESPONSE,		// response indicated but < 4 bytes of data
+	ALERR_INSUFFICIENT_DATA_FOR_HEADER,			// not enough to read object header
+	ALERR_INSUFFICIENT_DATA_FOR_OBJECTS,		// not enough to read the indicated objects
+	ALERR_UNKNOWN_GROUP_VAR,					// encounter an unknown group var while parsing
+	ALERR_START_STOP_MISMATCH,					// Start > Stop in a ranged header
+	ALERR_ILLEGAL_QUALIFIER_AND_OBJECT,			// The qualifier/object combination is invalid
+	ALERR_UNKNOWN_QUALIFIER,
+	ALERR_ILLEGAL_RANGE_AND_PREFIX,
+	ALERR_ITERATOR_OUT_OF_BOUNDS,
+	ALERR_ITERATOR_NO_DATA,
+	ALERR_TOO_MANY_VARIABLE_OBJECTS_IN_HEADER,	// Too many OT_SIZE_BY_VARIATION in header
 
-    // APPLICATION Layer Context
+	// Transport Layer
+	TLERR_NEW_FIR,
+	TLERR_MESSAGE_WITHOUT_FIR,
+	TLERR_NO_PAYLOAD,
+	TLERR_BAD_SEQUENCE,
+	TLERR_BAD_LENGTH,
+	TLERR_BUFFER_FULL,
+	TLERR_TIMEOUT,
 
-    ALERR_TIMEOUT,
-    ALERR_BAD_UNSOL_BIT,
-    ALERR_UNEXPECTED_CONFIRM,
-    ALERR_UNEXPECTED_RESPONSE,
-    ALERR_MULTI_FRAGEMENT_REQUEST,
-    ALERR_NOT_FIR_PACKET,
-    ALERR_BAD_FIR_FIN,
-    ALERR_BAD_SEQUENCE,
-    ALERR_BAD_CONFIRM_MESSAGE,
-    ALERR_FRAGMENT_TOO_LARGE,
-    ALERR_UNSOL_FLOOD,
-    ALERR_SOL_FLOOD,
-    ALERR_INVALID_PACKET,
-    ALERR_BAD_STATE,
+	// Link Frame Layer
+	DLERR_CRC,				//	CRC failure in header or data payload
+	DLERR_INVALID_LENGTH,	//	length parameter outside range [0,255]
+	DLERR_UNEXPECTED_DATA,	//  length > 5 for non-user data func code
+	DLERR_NO_DATA,			//  length == 5 but func code indicates data
+	DLERR_UNKNOWN_FUNC,		//  unknown function code
+	DLERR_UNEXPECTED_FCV,	//	FCV bit set unexpectedly, ie set on wrong func code
+	DLERR_UNEXPECTED_FCB,	//  FCB set unexpectedly
 
-    // Application Layer Parsing
+	// Data Link Layer
+	DLERR_UNKNOWN_ROUTE,	// carries 2 pieces of meta-data: SRC<uint16_t> and DEST<uint16_t>
+	DLERR_UNKNOWN_DESTINATION,
+	DLERR_UNKNOWN_SOURCE,
+	DLERR_CONFIRM_NOT_RECEIVED,
+	DLERR_NACK_RECEIVED,
+	DLERR_SEND_FAILED,
+	DLERR_REMOTE_LINKLAYER_NOT_SUPPORTED,
+	DLERR_REMOTE_BUFFERS_FULL_TIMEOUT,
+	DLERR_WRONG_FCB_ON_RECEIVE_DATA,
+	DLERR_WRONG_FCB_ON_TEST,
+	DLERR_UNEXPECTED_ACK,
+	DLERR_UNEXPECTED_FRAME,
+	DLERR_TIMEOUT_RETRY,
+	DLERR_TIMEOUT_NO_RETRY,
+	DLERR_MASTER_BIT_MATCH,
+	DLERR_PRI_IS_FLOODING,
 
-    ALERR_INSUFFICIENT_DATA_FOR_FRAG,			// fragment is less than 2 bytes
-    ALERR_INSUFFICIENT_DATA_FOR_RESPONSE,		// response indicated but < 4 bytes of data
-    ALERR_INSUFFICIENT_DATA_FOR_HEADER,			// not enough to read object header
-    ALERR_INSUFFICIENT_DATA_FOR_OBJECTS,		// not enough to read the indicated objects
-    ALERR_UNKNOWN_GROUP_VAR,					// encounter an unknown group var while parsing
-    ALERR_START_STOP_MISMATCH,					// Start > Stop in a ranged header
-    ALERR_ILLEGAL_QUALIFIER_AND_OBJECT,			// The qualifier/object combination is invalid
-    ALERR_UNKNOWN_QUALIFIER,
-    ALERR_ILLEGAL_RANGE_AND_PREFIX,
-    ALERR_ITERATOR_OUT_OF_BOUNDS,
-    ALERR_ITERATOR_NO_DATA,
-    ALERR_TOO_MANY_VARIABLE_OBJECTS_IN_HEADER,	// Too many OT_SIZE_BY_VARIATION in header
+	// General Errors
+	ERR_INDEX_OUT_OF_BOUNDS
 
-
-    /* TRANSPORT Layer */
-
-    TLERR_NEW_FIR,
-    TLERR_MESSAGE_WITHOUT_FIR,
-    TLERR_NO_PAYLOAD,
-    TLERR_BAD_SEQUENCE,
-    TLERR_BAD_LENGTH,
-    TLERR_BUFFER_FULL,
-    TLERR_TIMEOUT,
-
-    //used in linkframeparser
-    DLERR_CRC,				//	CRC failure in header or data payload
-    DLERR_INVALID_LENGTH,	//	length parameter outside range [0,255]
-    DLERR_UNEXPECTED_DATA,	//  length > 5 for non-user data func code
-    DLERR_NO_DATA,			//  length == 5 but func code indicates data
-    DLERR_UNKNOWN_FUNC,		//  unknown function code
-    DLERR_UNEXPECTED_FCV,	//	FCV bit set unexpectedly, ie set on wrong func code
-    DLERR_UNEXPECTED_FCB,	//  FCB set unexpectedly
-
-    /* ---- user in datalinklayer ----- */
-
-
-    /**
-     *	Carries 2 pieces of metadata, SOURCE<uint16_t> and DESTINATION<uint16_t>
-     */
-    DLERR_UNKNOWN_ROUTE,
-
-    DLERR_UNKNOWN_DESTINATION,
-    DLERR_UNKNOWN_SOURCE,
-    DLERR_CONFIRM_NOT_RECEIVED,
-    DLERR_NACK_RECEIVED,
-    DLERR_SEND_FAILED,
-    DLERR_REMOTE_LINKLAYER_NOT_SUPPORTED,
-    DLERR_REMOTE_BUFFERS_FULL_TIMEOUT,
-    DLERR_WRONG_FCB_ON_RECEIVE_DATA,
-    DLERR_WRONG_FCB_ON_TEST,
-    DLERR_UNEXPECTED_ACK,
-    DLERR_UNEXPECTED_FRAME,
-    DLERR_TIMEOUT_RETRY,
-    DLERR_TIMEOUT_NO_RETRY,
-    DLERR_MASTER_BIT_MATCH,
-    DLERR_PRI_IS_FLOODING,
-
-    //Used all over the place
-    ERR_INDEX_OUT_OF_BOUNDS
-
+	// Non-error Log Items
+	TIME_SYNC_OCCURRED
 
 };
 

--- a/DNP3/DNPConstants.h
+++ b/DNP3/DNPConstants.h
@@ -125,10 +125,10 @@ enum DNPErrorCodes {
 	DLERR_PRI_IS_FLOODING,
 
 	// General Errors
-	ERR_INDEX_OUT_OF_BOUNDS
+	ERR_INDEX_OUT_OF_BOUNDS,
 
 	// Non-error Log Items
-	TIME_SYNC_OCCURRED
+	TIME_SYNC_UPDATED
 
 };
 

--- a/DNP3/Slave.cpp
+++ b/DNP3/Slave.cpp
@@ -382,6 +382,10 @@ void Slave::HandleWriteTimeDate(HeaderReadIterator& arHWI)
 	mpTime->SetTime(val);
 
 	mIIN.SetNeedTime(false);
+
+	LogEntry le(LEV_EVENT, mpLogger->GetName(), LOCATION,
+			"Time synchronized with master", TIME_SYNC_UPDATED);
+	mpLogger->Log(le);
 }
 
 void Slave::HandleWrite(const APDU& arRequest)

--- a/DNP3/StartupTasks.cpp
+++ b/DNP3/StartupTasks.cpp
@@ -124,7 +124,6 @@ TaskResult TimeSync::_OnFinalResponse(const APDU& arAPDU)
 		return TR_CONTINUE;
 	}
 	else {
-
 		return TR_SUCCESS;
 	}
 }

--- a/Makefile.am
+++ b/Makefile.am
@@ -181,11 +181,13 @@ nobase_pkginclude_HEADERS= \
 	APL/CRC.h \
 	APL/DataInterfaces.h \
 	APL/DataTypes.h \
+	APL/DeleteAny.h \
 	APL/EventLockBase.h \
 	APL/EventLock.h \
 	APL/EventSet.h \
 	APL/Exception.h \
 	APL/FlexibleDataObserver.h \
+	APL/GetKeys.h \
 	APL/IEventLock.h \
 	APL/IHandlerAsync.h \
 	APL/INotifier.h \
@@ -195,6 +197,8 @@ nobase_pkginclude_HEADERS= \
 	APL/IPhysicalLayerObserver.h \
 	APL/IPhysicalLayerSource.h \
 	APL/ISubject.h \
+	APL/ITimer.h \
+	APL/ITimerSource.h \
 	APL/ITimeSource.h \
 	APL/ITransactable.h \
 	APL/LockBase.h \
@@ -255,7 +259,6 @@ nobase_pkginclude_HEADERS= \
 	APL/TimeBoost.h \
 	APL/Timeout.h \
 	APL/TimerASIO.h \
-	APL/ITimerSource.h \
 	APL/TimerSourceASIO.h \
 	APL/TimeSource.h \
 	APL/TimeTypes.h \


### PR DESCRIPTION
With the latest updates, the .cpp files got updated in Makefile.am, but a few header files were still missing.  This patch fixes that.
