### PR TITLE
Pull to fix autotools implementation of Swig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,8 @@ TestSingle.tiny.xml
 dnp3test
 testset
 
+__init__.py
+__init__.pyc
 pyopendnp3.py
 pyopendnp3.pyc
 

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ TestSingle.tiny.xml
 dnp3test
 testset
 
+pyopendnp3.py
+pyopendnp3.pyc
+
 /config/autotools/m4/libtool.m4
 /config/autotools/m4/ltoptions.m4
 /config/autotools/m4/ltsugar.m4

--- a/DNP3Java/.gitignore
+++ b/DNP3Java/.gitignore
@@ -1,2 +1,4 @@
 JavaDNP3.cpp
 JavaDNP3.h
+PythonDNP3.cpp
+PythonDNP3.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -380,7 +380,7 @@ nobase_pkginclude_HEADERS= \
 
 bin_PROGRAMS = testset
 
-testset_LDADD = libopendnp3.la $(TEST_BOOST_LIBS)
+testset_LDADD = libopendnp3.la $(CORE_BOOST_LIBS)
 testset_CFLAGS = -Itinyxml
 testset_SOURCES = \
 	APLXML/PhysicalLayerManagerXML.cpp \
@@ -414,7 +414,7 @@ testset_SOURCES = \
 
 noinst_PROGRAMS = dnp3test
 
-dnp3test_LDADD = libopendnp3.la $(CORE_BOOST_LIBS)
+dnp3test_LDADD = libopendnp3.la $(TEST_BOOST_LIBS)
 dnp3test_SOURCES = \
 	APLTestTools/AsyncPhysTestObject.cpp \
 	APLTestTools/AsyncTestObjectASIO.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -172,8 +172,8 @@ if WANT_PYTHON
 pkgpython_PYTHON = pyopendnp3.py
 pkgpyexec_LTLIBRARIES = _pyopendnp3.la
 _pyopendnp3_la_SOURCES = DNP3Java/PythonDNP3.cpp
-_pyopendnp3_la_CPPFLAGS = $(SWIG_PYTHON_CPPFLAGS)
-_pyopendnp3_la_LDFLAGS = -module
+_pyopendnp3_la_CPPFLAGS = $(SWIG_PYTHON_CPPFLAGS) $(PYTHON_CPPFLAGS)
+_pyopendnp3_la_LDFLAGS = -module $(PYTHON_LDFLAGS)
 _pyopendnp3_la_LIBADD = libopendnp3.la
 
 DNP3Java/PythonDNP3.cpp: DNP3Java/JavaDNP3.i

--- a/Makefile.am
+++ b/Makefile.am
@@ -11,6 +11,7 @@ AM_LDFLAGS = $(BOOST_LDFLAGS)
 lib_LTLIBRARIES = libopendnp3.la
 
 libopendnp3_la_LDFLAGS = -version-info 0:0:0
+libopendnp3_la_LIBADD = $(BOOST_LDFLAGS) -lboost_thread
 libopendnp3_la_SOURCES = \
 	APL/ASIOSerialHelpers.cpp \
 	APL/AsyncLayerInterfaces.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,10 +8,10 @@ ACLOCAL_AMFLAGS = -I config/autotools/m4
 AM_CXXFLAGS = $(BOOST_CPPFLAGS) -DBOOST_TEST_DYN_LINK -DBOOST_ASIO_ENABLE_CANCELIO -DBOOST_REGEX_NO_LIB
 AM_LDFLAGS = $(BOOST_LDFLAGS)
 
-lib_LTLIBRARIES = libopendnp3_apl.la libopendnp3_dnp3.la
+lib_LTLIBRARIES = libopendnp3.la
 
-libopendnp3_apl_la_LDFLAGS = -version-info 0:0:0
-libopendnp3_apl_la_SOURCES = \
+libopendnp3_la_LDFLAGS = -version-info 0:0:0
+libopendnp3_la_SOURCES = \
 	APL/ASIOSerialHelpers.cpp \
 	APL/AsyncLayerInterfaces.cpp \
 	APL/AsyncResult.cpp \
@@ -82,10 +82,7 @@ libopendnp3_apl_la_SOURCES = \
 	APL/TimingTools.cpp \
 	APL/ToHex.cpp \
 	APL/TrackingTaskGroup.cpp \
-	APL/Util.cpp
-
-libopendnp3_dnp3_la_LDFLAGS = -version-info 0:0:0
-libopendnp3_dnp3_la_SOURCES = \
+	APL/Util.cpp \
 	DNP3/AlwaysOpeningVtoRouter.cpp \
 	DNP3/APDUConstants.cpp \
 	DNP3/APDU.cpp \
@@ -157,9 +154,7 @@ libopendnp3_dnp3_la_SOURCES = \
 	DNP3/VtoWriter.cpp
 
 if JAVA
-lib_LTLIBRARIES += libopendnp3_java.la
-libopendnp3_java_la_LDFLAGS = -version-info 0:0:0
-libopendnp3_java_la_SOURCES = DNP3Java/JavaDNP3.cpp
+libopendnp3_la_SOURCES += DNP3Java/JavaDNP3.cpp
 DNP3Java/JavaDNP3.cpp: DNP3Java/JavaDNP3.i
 	mkdir -p $(top_srcdir)/src/main/java/org/totalgrid/reef/protocol/dnp3
 	swig -c++ -java \
@@ -381,7 +376,7 @@ nobase_pkginclude_HEADERS= \
 
 bin_PROGRAMS = testset
 
-testset_LDADD = libopendnp3_apl.la libopendnp3_dnp3.la $(BOOST_DATE_TIME_LIB) $(BOOST_THREAD_LIB) $(BOOST_PROGRAM_OPTIONS_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_UNIT_TEST_FRAMEWORK_LIB)
+testset_LDADD = libopendnp3.la $(BOOST_DATE_TIME_LIB) $(BOOST_THREAD_LIB) $(BOOST_PROGRAM_OPTIONS_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_UNIT_TEST_FRAMEWORK_LIB)
 testset_CFLAGS = -Itinyxml
 testset_SOURCES = \
 	APLXML/PhysicalLayerManagerXML.cpp \
@@ -415,7 +410,7 @@ testset_SOURCES = \
 
 noinst_PROGRAMS = dnp3test
 
-dnp3test_LDADD = libopendnp3_apl.la libopendnp3_dnp3.la $(BOOST_DATE_TIME_LIB) $(BOOST_THREAD_LIB) $(BOOST_PROGRAM_OPTIONS_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_UNIT_TEST_FRAMEWORK_LIB)
+dnp3test_LDADD = libopendnp3.la $(BOOST_DATE_TIME_LIB) $(BOOST_THREAD_LIB) $(BOOST_PROGRAM_OPTIONS_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_UNIT_TEST_FRAMEWORK_LIB)
 dnp3test_SOURCES = \
 	APLTestTools/AsyncPhysTestObject.cpp \
 	APLTestTools/AsyncTestObjectASIO.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -157,7 +157,7 @@ libopendnp3_la_SOURCES = \
 	DNP3/VtoTransmitTask.cpp \
 	DNP3/VtoWriter.cpp
 
-if JAVA
+if WANT_JAVA
 libopendnp3_la_SOURCES += DNP3Java/JavaDNP3.cpp
 DNP3Java/JavaDNP3.cpp: DNP3Java/JavaDNP3.i
 	mkdir -p $(top_srcdir)/src/main/java/org/totalgrid/reef/protocol/dnp3
@@ -165,7 +165,22 @@ DNP3Java/JavaDNP3.cpp: DNP3Java/JavaDNP3.i
 		-package org.totalgrid.reef.protocol.dnp3 \
 		-I$(top_srcdir) -I$(top_srcdir)/APL -I$(top_srcdir)/DNP3 \
 		-outdir $(top_srcdir)/src/main/java/org/totalgrid/reef/protocol/dnp3 \
-		-o $@ $^
+		-o DNP3Java/JavaDNP3.cpp $^
+endif
+
+if WANT_PYTHON
+pkgpython_PYTHON = pyopendnp3.py
+pkgpyexec_LTLIBRARIES = _pyopendnp3.la
+_pyopendnp3_la_SOURCES = DNP3Java/PythonDNP3.cpp
+_pyopendnp3_la_CPPFLAGS = $(SWIG_PYTHON_CPPFLAGS)
+_pyopendnp3_la_LDFLAGS = -module
+_pyopendnp3_la_LIBADD = libopendnp3.la
+
+DNP3Java/PythonDNP3.cpp: DNP3Java/JavaDNP3.i
+	swig -c++ -python \
+		-module pyopendnp3 \
+		-I$(top_srcdir) -I$(top_srcdir)/APL -I$(top_srcdir)/DNP3 \
+		-o DNP3Java/PythonDNP3.cpp $^
 endif
 
 nobase_pkginclude_HEADERS= \
@@ -505,10 +520,10 @@ docs-pdf:
 include config/autotools/mk/doxygen.mak
 include config/autotools/mk/lcov.mak
 
-clean-java:
-	-rm -rf DNP3Java/JavaDNP3.cpp DNP3Java/JavaDNP3.h $(top_srcdir)/src
+clean-swig:
+	-rm -rf DNP3Java/JavaDNP3.cpp DNP3Java/JavaDNP3.h DNP3Java/PythonDNP3.cpp DNP3Java/PythonDNP3.h $(top_srcdir)/src
 
-clean-local: clean-java clean-lcov
+clean-local: clean-swig clean-lcov
 
 .PHONY : astyle docs docs-html docs-pdf lcov lcov-report lcov-reset doxygen-run doxygen-doc $(DX_PS_GOAL) $(DX_PDF_GOAL)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -169,12 +169,15 @@ DNP3Java/JavaDNP3.cpp: DNP3Java/JavaDNP3.i
 endif
 
 if WANT_PYTHON
-pkgpython_PYTHON = pyopendnp3.py
+pkgpython_PYTHON = pyopendnp3.py __init__.py
 pkgpyexec_LTLIBRARIES = _pyopendnp3.la
 _pyopendnp3_la_SOURCES = DNP3Java/PythonDNP3.cpp
 _pyopendnp3_la_CPPFLAGS = $(SWIG_PYTHON_CPPFLAGS) $(PYTHON_CPPFLAGS)
 _pyopendnp3_la_LDFLAGS = -module $(PYTHON_LDFLAGS)
 _pyopendnp3_la_LIBADD = libopendnp3.la
+
+__init__.py:
+	touch $@
 
 DNP3Java/PythonDNP3.cpp: DNP3Java/JavaDNP3.i
 	swig -c++ -python \

--- a/Makefile.am
+++ b/Makefile.am
@@ -180,6 +180,7 @@ DNP3Java/PythonDNP3.cpp: DNP3Java/JavaDNP3.i
 	swig -c++ -python \
 		-module pyopendnp3 \
 		-I$(top_srcdir) -I$(top_srcdir)/APL -I$(top_srcdir)/DNP3 \
+		-outdir $(top_srcdir) \
 		-o DNP3Java/PythonDNP3.cpp $^
 endif
 
@@ -521,7 +522,10 @@ include config/autotools/mk/doxygen.mak
 include config/autotools/mk/lcov.mak
 
 clean-swig:
-	-rm -rf DNP3Java/JavaDNP3.cpp DNP3Java/JavaDNP3.h DNP3Java/PythonDNP3.cpp DNP3Java/PythonDNP3.h $(top_srcdir)/src
+	-rm -rf DNP3Java/JavaDNP3.cpp DNP3Java/JavaDNP3.h
+	-rm -rf DNP3Java/PythonDNP3.cpp DNP3Java/PythonDNP3.h
+	-rm -rf pyopendnp3.py pyopendnp3.pyc
+	-rm -rf $(top_srcdir)/src
 
 clean-local: clean-swig clean-lcov
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -5,13 +5,16 @@
 
 ACLOCAL_AMFLAGS = -I config/autotools/m4
 
+CORE_BOOST_LIBS  = $(BOOST_DATE_TIME_LIB) $(BOOST_THREAD_LIB) $(BOOST_PROGRAM_OPTIONS_LIB) $(BOOST_SYSTEM_LIB)
+TEST_BOOST_LIBS  = $(CORE_BOOST_LIBS) $(BOOST_UNIT_TEST_FRAMEWORK_LIB)
+
 AM_CXXFLAGS = $(BOOST_CPPFLAGS) -DBOOST_TEST_DYN_LINK -DBOOST_ASIO_ENABLE_CANCELIO -DBOOST_REGEX_NO_LIB
-AM_LDFLAGS = $(BOOST_LDFLAGS)
+AM_LDFLAGS  = $(BOOST_LDFLAGS)
 
 lib_LTLIBRARIES = libopendnp3.la
 
 libopendnp3_la_LDFLAGS = -version-info 0:0:0
-libopendnp3_la_LIBADD = $(BOOST_LDFLAGS) -lboost_thread
+libopendnp3_la_LIBADD = $(BOOST_LDFLAGS) $(CORE_BOOST_LIBS)
 libopendnp3_la_SOURCES = \
 	APL/ASIOSerialHelpers.cpp \
 	APL/AsyncLayerInterfaces.cpp \
@@ -377,7 +380,7 @@ nobase_pkginclude_HEADERS= \
 
 bin_PROGRAMS = testset
 
-testset_LDADD = libopendnp3.la $(BOOST_DATE_TIME_LIB) $(BOOST_THREAD_LIB) $(BOOST_PROGRAM_OPTIONS_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_UNIT_TEST_FRAMEWORK_LIB)
+testset_LDADD = libopendnp3.la $(TEST_BOOST_LIBS)
 testset_CFLAGS = -Itinyxml
 testset_SOURCES = \
 	APLXML/PhysicalLayerManagerXML.cpp \
@@ -411,7 +414,7 @@ testset_SOURCES = \
 
 noinst_PROGRAMS = dnp3test
 
-dnp3test_LDADD = libopendnp3.la $(BOOST_DATE_TIME_LIB) $(BOOST_THREAD_LIB) $(BOOST_PROGRAM_OPTIONS_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_UNIT_TEST_FRAMEWORK_LIB)
+dnp3test_LDADD = libopendnp3.la $(CORE_BOOST_LIBS)
 dnp3test_SOURCES = \
 	APLTestTools/AsyncPhysTestObject.cpp \
 	APLTestTools/AsyncTestObjectASIO.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -177,7 +177,7 @@ _pyopendnp3_la_LDFLAGS = -module $(PYTHON_LDFLAGS)
 _pyopendnp3_la_LIBADD = libopendnp3.la
 
 __init__.py:
-	touch $@
+	echo "from pyopendnp3 import *" > $@
 
 DNP3Java/PythonDNP3.cpp: DNP3Java/JavaDNP3.i
 	swig -c++ -python \

--- a/README
+++ b/README
@@ -268,6 +268,7 @@ Requirements:
   - libtool                         (required)
   - swig v1.3.17 or later           (required if 'configure --with-java')
   - Java JDK with JNI support       (required if 'configure --with-java')
+  - Python 2.6 or later             (required if 'configure --with-python')
 
 To start, first reinitialize autotools to be compatible with the version
 running on your system:
@@ -346,13 +347,24 @@ conforms to the style guidelines used for the project:
 
 Please run this utility before submitting any patches to the project.
 
-If you want to build the Java/Swig bindings for the OpenDNP3 library,
-make sure that your system has both swig and a valid JDK installed.
-Enable the build tree to create the Java library:
+If you want to build the Java bindings for the OpenDNP3 library, make
+sure that your system has both swig and a valid JDK installed.  Enable
+the build tree to create the Java library:
 
   autoreconf -f -i
   ./configure --with-java=/path/to/jdk/include
   make
 
 The Java source files are created in the 'src' directory structure.
+
+If you want to build the Python bindings for the OpenDNP3 library, make
+sure that your system has both swig and a valid Python interpreter
+installed.  Enable the build tree to create the Python library:
+
+  autoreconf -f -i
+  ./configure --with-python
+  make
+
+The Python library is called pyopendnp3.  The Python class and shared
+library are installed to the 'opendnp3' package directory.
 

--- a/config/autotools/m4/ax_python_devel.m4
+++ b/config/autotools/m4/ax_python_devel.m4
@@ -1,0 +1,325 @@
+# ===========================================================================
+#      http://www.gnu.org/software/autoconf-archive/ax_python_devel.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_PYTHON_DEVEL([version])
+#
+# DESCRIPTION
+#
+#   Note: Defines as a precious variable "PYTHON_VERSION". Don't override it
+#   in your configure.ac.
+#
+#   This macro checks for Python and tries to get the include path to
+#   'Python.h'. It provides the $(PYTHON_CPPFLAGS) and $(PYTHON_LDFLAGS)
+#   output variables. It also exports $(PYTHON_EXTRA_LIBS) and
+#   $(PYTHON_EXTRA_LDFLAGS) for embedding Python in your code.
+#
+#   You can search for some particular version of Python by passing a
+#   parameter to this macro, for example ">= '2.3.1'", or "== '2.4'". Please
+#   note that you *have* to pass also an operator along with the version to
+#   match, and pay special attention to the single quotes surrounding the
+#   version number. Don't use "PYTHON_VERSION" for this: that environment
+#   variable is declared as precious and thus reserved for the end-user.
+#
+#   This macro should work for all versions of Python >= 2.1.0. As an end
+#   user, you can disable the check for the python version by setting the
+#   PYTHON_NOVERSIONCHECK environment variable to something else than the
+#   empty string.
+#
+#   If you need to use this macro for an older Python version, please
+#   contact the authors. We're always open for feedback.
+#
+# LICENSE
+#
+#   Copyright (c) 2009 Sebastian Huber <sebastian-huber@web.de>
+#   Copyright (c) 2009 Alan W. Irwin <irwin@beluga.phys.uvic.ca>
+#   Copyright (c) 2009 Rafael Laboissiere <rafael@laboissiere.net>
+#   Copyright (c) 2009 Andrew Collier <colliera@ukzn.ac.za>
+#   Copyright (c) 2009 Matteo Settenvini <matteo@member.fsf.org>
+#   Copyright (c) 2009 Horst Knorr <hk_classes@knoda.org>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 8
+
+AU_ALIAS([AC_PYTHON_DEVEL], [AX_PYTHON_DEVEL])
+AC_DEFUN([AX_PYTHON_DEVEL],[
+	#
+	# Allow the use of a (user set) custom python version
+	#
+	AC_ARG_VAR([PYTHON_VERSION],[The installed Python
+		version to use, for example '2.3'. This string
+		will be appended to the Python interpreter
+		canonical name.])
+
+	AC_PATH_PROG([PYTHON],[python[$PYTHON_VERSION]])
+	if test -z "$PYTHON"; then
+	   AC_MSG_ERROR([Cannot find python$PYTHON_VERSION in your system path])
+	   PYTHON_VERSION=""
+	fi
+
+	#
+	# Check for a version of Python >= 2.1.0
+	#
+	AC_MSG_CHECKING([for a version of Python >= '2.1.0'])
+	ac_supports_python_ver=`$PYTHON -c "import sys; \
+		ver = sys.version.split ()[[0]]; \
+		print (ver >= '2.1.0')"`
+	if test "$ac_supports_python_ver" != "True"; then
+		if test -z "$PYTHON_NOVERSIONCHECK"; then
+			AC_MSG_RESULT([no])
+			AC_MSG_FAILURE([
+This version of the AC@&t@_PYTHON_DEVEL macro
+doesn't work properly with versions of Python before
+2.1.0. You may need to re-run configure, setting the
+variables PYTHON_CPPFLAGS, PYTHON_LDFLAGS, PYTHON_SITE_PKG,
+PYTHON_EXTRA_LIBS and PYTHON_EXTRA_LDFLAGS by hand.
+Moreover, to disable this check, set PYTHON_NOVERSIONCHECK
+to something else than an empty string.
+])
+		else
+			AC_MSG_RESULT([skip at user request])
+		fi
+	else
+		AC_MSG_RESULT([yes])
+	fi
+
+	#
+	# if the macro parameter ``version'' is set, honour it
+	#
+	if test -n "$1"; then
+		AC_MSG_CHECKING([for a version of Python $1])
+		ac_supports_python_ver=`$PYTHON -c "import sys; \
+			ver = sys.version.split ()[[0]]; \
+			print (ver $1)"`
+		if test "$ac_supports_python_ver" = "True"; then
+		   AC_MSG_RESULT([yes])
+		else
+			AC_MSG_RESULT([no])
+			AC_MSG_ERROR([this package requires Python $1.
+If you have it installed, but it isn't the default Python
+interpreter in your system path, please pass the PYTHON_VERSION
+variable to configure. See ``configure --help'' for reference.
+])
+			PYTHON_VERSION=""
+		fi
+	fi
+
+	#
+	# Check if you have distutils, else fail
+	#
+	AC_MSG_CHECKING([for the distutils Python package])
+	ac_distutils_result=`$PYTHON -c "import distutils" 2>&1`
+	if test -z "$ac_distutils_result"; then
+		AC_MSG_RESULT([yes])
+	else
+		AC_MSG_RESULT([no])
+		AC_MSG_ERROR([cannot import Python module "distutils".
+Please check your Python installation. The error was:
+$ac_distutils_result])
+		PYTHON_VERSION=""
+	fi
+
+	#
+	# Check for Python include path
+	#
+	AC_MSG_CHECKING([for Python include path])
+	if test -z "$PYTHON_CPPFLAGS"; then
+		python_path=`$PYTHON -c "import distutils.sysconfig; \
+			print (distutils.sysconfig.get_python_inc ());"`
+		if test -n "${python_path}"; then
+			python_path="-I$python_path"
+		fi
+		PYTHON_CPPFLAGS=$python_path
+	fi
+	AC_MSG_RESULT([$PYTHON_CPPFLAGS])
+	AC_SUBST([PYTHON_CPPFLAGS])
+
+	#
+	# Check for Python library path
+	#
+	AC_MSG_CHECKING([for Python library path])
+	if test -z "$PYTHON_LDFLAGS"; then
+		# (makes two attempts to ensure we've got a version number
+		# from the interpreter)
+		ac_python_version=`cat<<EOD | $PYTHON -
+
+# join all versioning strings, on some systems
+# major/minor numbers could be in different list elements
+from distutils.sysconfig import *
+ret = ''
+for e in get_config_vars ('VERSION'):
+	if (e != None):
+		ret += e
+print (ret)
+EOD`
+
+		if test -z "$ac_python_version"; then
+			if test -n "$PYTHON_VERSION"; then
+				ac_python_version=$PYTHON_VERSION
+			else
+				ac_python_version=`$PYTHON -c "import sys; \
+					print (sys.version[[:3]])"`
+			fi
+		fi
+
+		# Make the versioning information available to the compiler
+		AC_DEFINE_UNQUOTED([HAVE_PYTHON], ["$ac_python_version"],
+                                   [If available, contains the Python version number currently in use.])
+
+		# First, the library directory:
+		ac_python_libdir=`cat<<EOD | $PYTHON -
+
+# There should be only one
+import distutils.sysconfig
+for e in distutils.sysconfig.get_config_vars ('LIBDIR'):
+	if e != None:
+		print (e)
+		break
+EOD`
+
+		# Before checking for libpythonX.Y, we need to know
+		# the extension the OS we're on uses for libraries
+		# (we take the first one, if there's more than one fix me!):
+		ac_python_soext=`$PYTHON -c \
+		  "import distutils.sysconfig; \
+		  print (distutils.sysconfig.get_config_vars('SO')[[0]])"`
+
+		# Now, for the library:
+		ac_python_soname=`$PYTHON -c \
+		  "import distutils.sysconfig; \
+		  print (distutils.sysconfig.get_config_vars('LDLIBRARY')[[0]])"`
+
+		# Strip away extension from the end to canonicalize its name:
+		ac_python_library=`echo "$ac_python_soname" | sed "s/${ac_python_soext}$//"`
+
+		# This small piece shamelessly adapted from PostgreSQL python macro;
+		# credits goes to momjian, I think. I'd like to put the right name
+		# in the credits, if someone can point me in the right direction... ?
+		#
+		if test -n "$ac_python_libdir" -a -n "$ac_python_library" \
+			-a x"$ac_python_library" != x"$ac_python_soname"
+		then
+			# use the official shared library
+			ac_python_library=`echo "$ac_python_library" | sed "s/^lib//"`
+			PYTHON_LDFLAGS="-L$ac_python_libdir -l$ac_python_library"
+		else
+			# old way: use libpython from python_configdir
+			ac_python_libdir=`$PYTHON -c \
+			  "from distutils.sysconfig import get_python_lib as f; \
+			  import os; \
+			  print (os.path.join(f(plat_specific=1, standard_lib=1), 'config'));"`
+			PYTHON_LDFLAGS="-L$ac_python_libdir -lpython$ac_python_version"
+		fi
+
+		if test -z "PYTHON_LDFLAGS"; then
+			AC_MSG_ERROR([
+  Cannot determine location of your Python DSO. Please check it was installed with
+  dynamic libraries enabled, or try setting PYTHON_LDFLAGS by hand.
+			])
+		fi
+	fi
+	AC_MSG_RESULT([$PYTHON_LDFLAGS])
+	AC_SUBST([PYTHON_LDFLAGS])
+
+	#
+	# Check for site packages
+	#
+	AC_MSG_CHECKING([for Python site-packages path])
+	if test -z "$PYTHON_SITE_PKG"; then
+		PYTHON_SITE_PKG=`$PYTHON -c "import distutils.sysconfig; \
+			print (distutils.sysconfig.get_python_lib(0,0));"`
+	fi
+	AC_MSG_RESULT([$PYTHON_SITE_PKG])
+	AC_SUBST([PYTHON_SITE_PKG])
+
+	#
+	# libraries which must be linked in when embedding
+	#
+	AC_MSG_CHECKING(python extra libraries)
+	if test -z "$PYTHON_EXTRA_LIBS"; then
+	   PYTHON_EXTRA_LIBS=`$PYTHON -c "import distutils.sysconfig; \
+                conf = distutils.sysconfig.get_config_var; \
+                print (conf('LOCALMODLIBS') + ' ' + conf('LIBS'))"`
+	fi
+	AC_MSG_RESULT([$PYTHON_EXTRA_LIBS])
+	AC_SUBST(PYTHON_EXTRA_LIBS)
+
+	#
+	# linking flags needed when embedding
+	#
+	AC_MSG_CHECKING(python extra linking flags)
+	if test -z "$PYTHON_EXTRA_LDFLAGS"; then
+		PYTHON_EXTRA_LDFLAGS=`$PYTHON -c "import distutils.sysconfig; \
+			conf = distutils.sysconfig.get_config_var; \
+			print (conf('LINKFORSHARED'))"`
+	fi
+	AC_MSG_RESULT([$PYTHON_EXTRA_LDFLAGS])
+	AC_SUBST(PYTHON_EXTRA_LDFLAGS)
+
+	#
+	# final check to see if everything compiles alright
+	#
+	AC_MSG_CHECKING([consistency of all components of python development environment])
+	# save current global flags
+	ac_save_LIBS="$LIBS"
+	ac_save_CPPFLAGS="$CPPFLAGS"
+	LIBS="$ac_save_LIBS $PYTHON_LDFLAGS $PYTHON_EXTRA_LDFLAGS $PYTHON_EXTRA_LIBS"
+	CPPFLAGS="$ac_save_CPPFLAGS $PYTHON_CPPFLAGS"
+	AC_LANG_PUSH([C])
+	AC_LINK_IFELSE([
+		AC_LANG_PROGRAM([[#include <Python.h>]],
+				[[Py_Initialize();]])
+		],[pythonexists=yes],[pythonexists=no])
+	AC_LANG_POP([C])
+	# turn back to default flags
+	CPPFLAGS="$ac_save_CPPFLAGS"
+	LIBS="$ac_save_LIBS"
+
+	AC_MSG_RESULT([$pythonexists])
+
+        if test ! "x$pythonexists" = "xyes"; then
+	   AC_MSG_FAILURE([
+  Could not link test program to Python. Maybe the main Python library has been
+  installed in some non-standard library path. If so, pass it to configure,
+  via the LDFLAGS environment variable.
+  Example: ./configure LDFLAGS="-L/usr/non-standard-path/python/lib"
+  ============================================================================
+   ERROR!
+   You probably have to install the development version of the Python package
+   for your distribution.  The exact name of this package varies among them.
+  ============================================================================
+	   ])
+	  PYTHON_VERSION=""
+	fi
+
+	#
+	# all done!
+	#
+])

--- a/configure.ac
+++ b/configure.ac
@@ -79,6 +79,8 @@ AC_PROG_INSTALL
 AC_PROG_MKDIR_P
 AC_PROG_SED
 
+want_swig="no"
+
 AC_ARG_WITH([java],
   [AS_HELP_STRING([--with-java@<:@=ARG@:>@],
     [use the Java JDK from a standard location (ARG=yes),
@@ -98,18 +100,53 @@ AC_ARG_WITH([java],
     ],
     [want_java="no"])
 if test "$want_java" = yes; then
-  dnl Add the Java JDK include path to the CPPFLAGS
+  want_swig="yes"
   if test "x$ac_java_path" != "x"; then
     CPPFLAGS="$CPPFLAGS -I$ac_java_path"
   fi
-  dnl Now see if the jni.h file can even be found
   AC_CHECK_HEADERS([jni.h]	,,AC_MSG_ERROR(missing header))
-  dnl Setup all other dependencies
-  AX_PKG_SWIG(1.3.17, [], [ AC_MSG_ERROR([SWIG is required to build.]) ])
+fi
+AM_CONDITIONAL(WANT_JAVA, [test "$want_java" = yes])
+
+AC_ARG_WITH([python],
+  [AS_HELP_STRING([--with-python@<:@=ARG@:>@],
+    [use the Python headers from a standard location (ARG=yes),
+     from the specified location (ARG=<path>),
+     or disable it (ARG=no)
+     @<:@ARG=yes@:>@ ])],
+    [
+    if test "$withval" = "no"; then
+        want_python="no"
+    elif test "$withval" = "yes"; then
+        want_python="yes"
+        ac_python_path=""
+    else
+        want_python="yes"
+        ac_python_path="$withval"
+    fi
+    ],
+    [want_python="no"])
+if test "$want_python" = yes; then
+  want_swig="yes"
+  if test "x$ac_python_path" != "x"; then
+    CPPFLAGS="$CPPFLAGS -I$ac_python_path"
+  fi
+  AM_PATH_PYTHON([2.6],,AC_MSG_ERROR(Python 2.6 or later not found))
+  AC_CHECK_LIB([python$PYTHON_VERSION], [PyObject_Malloc]  ,,AC_MSG_ERROR(missing library))
+  AC_CHECK_LIB([python$PYTHON_VERSION], [PyExc_ValueError] ,,AC_MSG_ERROR(missing library))
+  AC_CHECK_LIB([python$PYTHON_VERSION], [_Py_NoneStruct]   ,,AC_MSG_ERROR(missing library))
+fi
+AM_CONDITIONAL(WANT_PYTHON, [test "$want_python" = yes])
+
+if test "$want_swig" = yes; then
+  AX_PKG_SWIG(1.3.21, [], [ AC_MSG_ERROR([SWIG is required to build.]) ])
   AX_SWIG_ENABLE_CXX
   AX_SWIG_MULTI_MODULE_SUPPORT
+  if test "$want_python" = yes; then
+    SWIG_PYTHON
+  fi
 fi
-AM_CONDITIONAL(JAVA, [test "$want_java" = yes])
+AM_CONDITIONAL(SWIG_ENABLED, [test "$want_swig" = yes])
 
 LT_INIT
 dnl AX_LIBTOOLIZE_CFLAGS(CFLAGS)
@@ -154,6 +191,7 @@ LIBS:                       ${LIBS}
 
 java support:               ${want_java}
 lcov support:               ${ac_lcov_enabled}
+python support:             ${want_python}
 
 shared libraries:           ${enable_shared}
 static libraries:           ${enable_static}

--- a/configure.ac
+++ b/configure.ac
@@ -128,13 +128,13 @@ AC_ARG_WITH([python],
     [want_python="no"])
 if test "$want_python" = yes; then
   want_swig="yes"
-  if test "x$ac_python_path" != "x"; then
-    CPPFLAGS="$CPPFLAGS -I$ac_python_path"
-  fi
   AM_PATH_PYTHON([2.6],,AC_MSG_ERROR(Python 2.6 or later not found))
   AC_CHECK_LIB([python$PYTHON_VERSION], [PyObject_Malloc]  ,,AC_MSG_ERROR(missing library))
   AC_CHECK_LIB([python$PYTHON_VERSION], [PyExc_ValueError] ,,AC_MSG_ERROR(missing library))
   AC_CHECK_LIB([python$PYTHON_VERSION], [_Py_NoneStruct]   ,,AC_MSG_ERROR(missing library))
+  if test "x$ac_python_path" != "x"; then
+    CPPFLAGS="$CPPFLAGS -I$ac_python_path"
+  fi
 fi
 AM_CONDITIONAL(WANT_PYTHON, [test "$want_python" = yes])
 

--- a/configure.ac
+++ b/configure.ac
@@ -152,7 +152,9 @@ CXXFLAGS:                   ${CXXFLAGS}
 LDFLAGS:                    ${LDFLAGS}
 LIBS:                       ${LIBS}
 
+java support:               ${want_java}
 lcov support:               ${ac_lcov_enabled}
+
 shared libraries:           ${enable_shared}
 static libraries:           ${enable_static}
 -----------------------------------------------------


### PR DESCRIPTION
The original implementation of autotools attempted to create 3 shared libraries, which left a series of unresolved dependencies between them.  To simplify things and get Swig running, autotools now produces a single shared library called "libopendnp3."
