### PR TITLE
Ran into a small error during compilation (make) and these changes resolve that. Error: DNP3XML/XmlToConfig.h: In instantiation of ‘static void apl::dnp::XmlToConfig::AddCommandData(const std::vector<T*>&, std::vector<apl::dnp::ControlRecord>&) [with T = 

### DIFF
--- a/DNP3XML/XmlToConfig.cpp
+++ b/DNP3XML/XmlToConfig.cpp
@@ -213,7 +213,7 @@ DeviceTemplate XmlToConfig::Convert(const APLXML_DNP::DeviceTemplate_t& arCfg, b
 	return t;
 }
 
-CommandModes ConvertMode(const std::string& arMode)
+CommandModes XmlToConfig::ConvertMode(const std::string& arMode)
 {
 	if(arMode == "SBO") return CM_SBO_ONLY;
 	if(arMode == "DO_ONLY") return CM_DO_ONLY;

--- a/DNP3XML/XmlToConfig.h
+++ b/DNP3XML/XmlToConfig.h
@@ -84,6 +84,7 @@ public:
 	static SlaveConfig Convert(const APLXML_DNP::SlaveConfig_t& arCfg, const APLXML_DNP::AppLayer_t& arApp);
 	static VtoConfig Convert(const APLXML_DNP::VtoPorts_t& arCfg);
 	static DeviceTemplate Convert( const APLXML_DNP::DeviceTemplate_t& arCfg, bool aStartOnline = false);
+	static CommandModes ConvertMode(const std::string& arMode);
 
 private:
 


### PR DESCRIPTION
Ran into a small error during compilation (make) and these changes resolve that.
DNP3XML/XmlToConfig.h:123:4: error: ‘ConvertMode’ was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation [-fpermissive]
...
make[1]: **\* [DNP3XML/XmlToConfig.o] Error 1
make[1]: Leaving directory `/home/.../software_engineering/scada/dnp3/dnp3_gec/dnp3'
make: **\* [all] Error 2
